### PR TITLE
Handle counter rollovers correctly

### DIFF
--- a/bndstat.go
+++ b/bndstat.go
@@ -157,8 +157,8 @@ func bndstat() error {
 			return nil
 		}
 
-		time.Sleep(intervalDuration)
 		glog.Flush()
+		time.Sleep(intervalDuration)
 	}
 
 	return nil

--- a/bndstat.go
+++ b/bndstat.go
@@ -158,6 +158,7 @@ func bndstat() error {
 		}
 
 		time.Sleep(intervalDuration)
+		glog.Flush()
 	}
 
 	return nil

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -16,7 +16,6 @@ import (
 
 var maxVal32 = uint64(math.Pow(2, 32))
 var maxVal64 = uint64(math.Pow(2, 64))
-var tbps = math.Pow(2, float64(Tbps))
 
 // Linux implements the Reporter interface for linux systems.
 type Linux struct {
@@ -80,7 +79,7 @@ func (l *Linux) Report() (*Stats, error) {
 		switch {
 
 		// 1 Tbps is faster than any hardware as of 2020.
-		case in > tbps || out > tbps:
+		case in > Tbps.Base2() || out > Tbps.Base2():
 			glog.Warningf("Triggering data dump because very large rate found")
 			trigger = true
 

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -162,7 +162,7 @@ func (l *Linux) stats() *Stats {
 		// Guess the max counter size in case we've had a rollover. This isn't
 		// strictly correct but would only fail in the case of a 64-bit counter that
 		// has experienced over 18 Exabits of traffic between probes.
-    // TODO: this needs to be per device maybe?
+		// TODO: this needs to be per device maybe?
 		guess := maxVal32
 		if l.maxCounter > maxVal32 {
 			guess = maxVal64

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kr/pretty"
 )
 
+const netDevCounterSize = 32
+
 // Linux implements the Reporter interface for linux systems.
 type Linux struct {
 	devices     map[string]*deviceData
@@ -47,7 +49,7 @@ type singleRead struct {
 func NewLinux() *Linux {
 	return &Linux{
 		devices:     map[string]*deviceData{},
-		counterSize: 32,
+		counterSize: netDevCounterSize,
 	}
 }
 

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -188,6 +188,15 @@ func (l *Linux) stats() *Stats {
 			bytesOut: outDiff,
 		}
 		stats.devices[device] = s
+
+		if glog.V(2) {
+			in, out, err := stats.Avg(device, Kbps)
+			if err != nil {
+				glog.Errorf("Erroring getting avg() from %s: %s", device, err)
+			} else {
+				glog.V(2).Infof("%s: in=%.4f kbps, out=%.4f kbps", device, in, out)
+			}
+		}
 	}
 
 	return stats

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -16,6 +16,7 @@ import (
 
 var maxVal32 = uint64(math.Pow(2, 32))
 var maxVal64 = uint64(math.Pow(2, 64))
+var tbps = math.Pow(2, float64(Tbps))
 
 // Linux implements the Reporter interface for linux systems.
 type Linux struct {
@@ -70,17 +71,19 @@ func (l *Linux) Report() (*Stats, error) {
 
 	// Look for anything that should trigger a raw data dump to debug bad data rates.
 	for _, device := range stats.Devices() {
-		in, out, err := stats.Avg(device, Kbps)
+		in, out, err := stats.Avg(device, Bps)
 		if err != nil {
 			return &Stats{}, fmt.Errorf("could not get average from %s", device)
 		}
 
 		trigger := false
 		switch {
+
 		// 1 Tbps is faster than any hardware as of 2020.
-		case in > 1000000000 || out > 1000000000:
+		case in > tbps || out > tbps:
 			glog.Warningf("Triggering data dump because very large rate found")
 			trigger = true
+
 		case in < 0 || out < 0:
 			glog.Warningf("Triggering data dump because negative rate found")
 			trigger = true

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -101,7 +101,7 @@ func (l *Linux) Report() (*Stats, error) {
 
 // dumpRawText logs the raw text from /proc/net/dev for each device.
 func (l *Linux) dumpRawText(device string) {
-	glog.Infof("Dumping /prov/net/dev data for %s", device)
+	glog.Infof("Dumping /proc/net/dev data for %s", device)
 
 	data, ok := l.devices[device]
 	if !ok {

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -2,6 +2,7 @@ package throughput
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/kr/pretty"
 )
 
 // Linux implements the Reporter interface for linux systems.
@@ -27,6 +29,8 @@ type deviceData struct {
 	currentTime     time.Time
 	currentBytesIn  uint64
 	currentBytesOut uint64
+
+	rawText [shiftSize]string
 }
 
 // singleRead is the struct representing the bytesIn and bytesOut of a device at
@@ -35,6 +39,7 @@ type singleRead struct {
 	name     string
 	bytesIn  uint64
 	bytesOut uint64
+	rawText  string
 }
 
 // NewLinux returns a pointer to an initialized Linux.
@@ -50,13 +55,46 @@ func (l *Linux) Report() (*Stats, error) {
 		return &Stats{}, err
 	}
 
-	srs, err := l.parseNetDev(p)
+	srs, err := parseNetDev(p)
 	if err != nil {
 		return &Stats{}, err
 	}
 
 	l.update(srs, time.Now())
+	stats := l.stats()
+
+	// Look for anything that shoud trigger a raw data dump.
+	for _, device := range stats.Devices() {
+		in, out, err := stats.Avg(device, Kbps)
+		if err != nil {
+			return &Stats{}, fmt.Errorf("could not get average from %s", device)
+		}
+		if in > 500000 || out > 500000 {
+			glog.Errorf("Big number detected on %s", device)
+			glog.Infof("  in=%f", in)
+			glog.Infof("  out=%f", out)
+			glog.Infof("  stats:\n%s", pretty.Sprint(stats))
+			l.dumpRawText(device)
+			glog.Flush()
+		}
+	}
+
 	return l.stats(), nil
+}
+
+// dumpRawText logs the raw text from /proc/net/dev for each device.
+func (l *Linux) dumpRawText(device string) {
+	glog.Infof("Dumping /prov/net/dev data for %s", device)
+
+	data, ok := l.devices[device]
+	if !ok {
+		glog.Errorf("dumpRawText on device that does not exist: %s", device)
+		return
+	}
+
+	for i, t := range data.rawText {
+		glog.Infof("  [%d] %s", i, t)
+	}
 }
 
 // update l.devices with info from a slice of singleReads.
@@ -77,6 +115,9 @@ func (l *Linux) update(srs []*singleRead, now time.Time) {
 		d.currentTime = now
 		d.currentBytesIn = sr.bytesIn
 		d.currentBytesOut = sr.bytesOut
+
+		d.shiftRawText()
+		d.rawText[0] = sr.rawText
 	}
 }
 
@@ -102,7 +143,7 @@ func (l *Linux) stats() *Stats {
 // /proc/net/dev. It returns a slice of singleReads, populating each element
 // with each device found. If the input byte slice does not match the correct
 // format, an empty slice will be returned.
-func (l *Linux) parseNetDev(i io.Reader) ([]*singleRead, error) {
+func parseNetDev(i io.Reader) ([]*singleRead, error) {
 	srs := []*singleRead{}
 
 	s := bufio.NewScanner(i)
@@ -131,6 +172,7 @@ func (l *Linux) parseNetDev(i io.Reader) ([]*singleRead, error) {
 				name:     dev,
 				bytesIn:  uint64(bytesRecv),
 				bytesOut: uint64(bytesTrans),
+				rawText:  s.Text(),
 			}
 			srs = append(srs, sr)
 		}
@@ -141,4 +183,13 @@ func (l *Linux) parseNetDev(i io.Reader) ([]*singleRead, error) {
 	}
 
 	return srs, nil
+}
+
+const shiftSize = 4
+
+// Shift raw data: 0 is latest, shiftSize is the earliest.
+func (d *deviceData) shiftRawText() {
+	for i := shiftSize - 1; i > 0; i-- {
+		d.rawText[i] = d.rawText[i-1]
+	}
 }

--- a/throughput/linux.go
+++ b/throughput/linux.go
@@ -162,6 +162,7 @@ func (l *Linux) stats() *Stats {
 		// Guess the max counter size in case we've had a rollover. This isn't
 		// strictly correct but would only fail in the case of a 64-bit counter that
 		// has experienced over 18 Exabits of traffic between probes.
+    // TODO: this needs to be per device maybe?
 		guess := maxVal32
 		if l.maxCounter > maxVal32 {
 			guess = maxVal64

--- a/throughput/linux_test.go
+++ b/throughput/linux_test.go
@@ -426,6 +426,41 @@ func TestStats(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "unsig 32-bit rollover, out, w/ another 64-bit device",
+			state: map[string]*deviceData{
+				"eth0-32": {
+					lastTime:        time.Unix(1, 0),
+					lastBytesIn:     0,
+					lastBytesOut:    maxVal32 - 10,
+					currentTime:     time.Unix(2, 0),
+					currentBytesIn:  0,
+					currentBytesOut: 10,
+				},
+				"eth1-64": {
+					lastTime:        time.Unix(1, 0),
+					lastBytesIn:     0,
+					lastBytesOut:    maxVal32 * 2,
+					currentTime:     time.Unix(2, 0),
+					currentBytesIn:  0,
+					currentBytesOut: maxVal32*2 + 10,
+				},
+			},
+			want: &Stats{
+				devices: map[string]*stat{
+					"eth0-32": {
+						bytesIn:  0,
+						bytesOut: 20,
+						elapsed:  time.Unix(2, 0).Sub(time.Unix(1, 0)),
+					},
+					"eth1-64": {
+						bytesIn:  0,
+						bytesOut: 10,
+						elapsed:  time.Unix(2, 0).Sub(time.Unix(1, 0)),
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/throughput/linux_test.go
+++ b/throughput/linux_test.go
@@ -2,7 +2,6 @@ package throughput
 
 import (
 	"bytes"
-	"math"
 	"testing"
 	"time"
 
@@ -10,9 +9,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/kr/pretty"
 )
-
-var maxVal32 = uint64(math.Pow(2, 32))
-var maxVal64 = uint64(math.Pow(2, 64))
 
 // Ensure the Linux struct satisfies the Reporter interface. Since not
 // implementing the interface is a compile time error, there's no value
@@ -260,10 +256,7 @@ func TestUpdate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			l := &Linux{
-				devices:     test.state,
-				counterSize: netDevCounterSize,
-			}
+			l := &Linux{devices: test.state}
 			l.update(test.input, test.now)
 
 			o := []cmp.Option{
@@ -279,20 +272,17 @@ func TestUpdate(t *testing.T) {
 
 func TestStats(t *testing.T) {
 	tests := []struct {
-		name       string
-		maxCounter uint64
-		state      map[string]*deviceData
-		want       *Stats
+		name  string
+		state map[string]*deviceData
+		want  *Stats
 	}{
 		{
-			name:       "trivial",
-			maxCounter: maxVal32,
-			state:      map[string]*deviceData{},
-			want:       &Stats{},
+			name:  "trivial",
+			state: map[string]*deviceData{},
+			want:  &Stats{},
 		},
 		{
-			name:       "simple",
-			maxCounter: maxVal32,
+			name: "simple",
 			state: map[string]*deviceData{
 				"eth0": {
 					lastTime:        time.Unix(1, 0),
@@ -314,8 +304,7 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:       "two devices",
-			maxCounter: maxVal32,
+			name: "two devices",
 			state: map[string]*deviceData{
 				"eth0": {
 					lastTime:        time.Unix(1, 0),
@@ -350,8 +339,7 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:       "unsig 64-bit rollover, in",
-			maxCounter: maxVal64,
+			name: "unsig 64-bit rollover, in",
 			state: map[string]*deviceData{
 				"eth0": {
 					lastTime:        time.Unix(1, 0),
@@ -373,8 +361,7 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:       "unsig 64-bit rollover, out",
-			maxCounter: maxVal64,
+			name: "unsig 64-bit rollover, out",
 			state: map[string]*deviceData{
 				"eth0": {
 					lastTime:        time.Unix(1, 0),
@@ -396,8 +383,7 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:       "unsig 32-bit rollover, in",
-			maxCounter: maxVal32,
+			name: "unsig 32-bit rollover, in",
 			state: map[string]*deviceData{
 				"eth0": {
 					lastTime:        time.Unix(1, 0),
@@ -419,8 +405,7 @@ func TestStats(t *testing.T) {
 			},
 		},
 		{
-			name:       "unsig 32-bit rollover, out",
-			maxCounter: maxVal32,
+			name: "unsig 32-bit rollover, out",
 			state: map[string]*deviceData{
 				"eth0": {
 					lastTime:        time.Unix(1, 0),
@@ -447,7 +432,6 @@ func TestStats(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			l := NewLinux()
 			l.devices = test.state
-			l.maxCounter = test.maxCounter
 
 			got := l.stats()
 

--- a/throughput/stat.go
+++ b/throughput/stat.go
@@ -41,7 +41,7 @@ func (s *Stats) Devices() []string {
 // Avg returns the average throughput for the device, in the units specified.
 // If the device does not exist, zeros are returned.
 //
-// TODO: test needed, return error when no device found (don't be lazy)
+// TODO: test needed
 func (s *Stats) Avg(device string, unit Unit) (in float64, out float64, err error) {
 	stat, ok := s.devices[device]
 	if !ok {

--- a/throughput/stat.go
+++ b/throughput/stat.go
@@ -39,8 +39,6 @@ func (s *Stats) Devices() []string {
 
 // Avg returns the average throughput for the device, in the units specified.
 // If the device does not exist, zeros are returned.
-//
-// TODO: test needed
 func (s *Stats) Avg(device string, unit Unit) (in float64, out float64, err error) {
 	stat, ok := s.devices[device]
 	if !ok {

--- a/throughput/stat.go
+++ b/throughput/stat.go
@@ -2,7 +2,6 @@ package throughput
 
 import (
 	"fmt"
-	"math"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func (s *Stats) Avg(device string, unit Unit) (in float64, out float64, err erro
 		return 0, 0, fmt.Errorf("device, %s, not found", device)
 	}
 
-	div := math.Pow(2, float64(unit))
+	div := unit.Base2()
 	in = (float64(stat.bytesIn*8) / div) / stat.elapsed.Seconds()
 	out = (float64(stat.bytesOut*8) / div) / stat.elapsed.Seconds()
 	return in, out, nil

--- a/throughput/stat_test.go
+++ b/throughput/stat_test.go
@@ -1,0 +1,113 @@
+package throughput
+
+import (
+	"testing"
+	"time"
+)
+
+var testAvgData = &Stats{
+	devices: map[string]*stat{
+		"notraffic": {
+			bytesIn:  0,
+			bytesOut: 0,
+			elapsed:  time.Second,
+		},
+		"onesec": {
+			bytesIn:  128,
+			bytesOut: 256,
+			elapsed:  time.Second,
+		},
+		"fivesec": {
+			bytesIn:  81776,
+			bytesOut: 63073,
+			elapsed:  5 * time.Second,
+		},
+	},
+}
+
+func TestAvg(t *testing.T) {
+	tests := []struct {
+		name        string
+		device      string
+		unit        Unit
+		inWant      float64
+		outWant     float64
+		errExpected bool
+	}{
+		{
+			name:        "notraffic (bps)",
+			device:      "notraffic",
+			unit:        Bps,
+			inWant:      0.0,
+			outWant:     0.0,
+			errExpected: false,
+		},
+		{
+			name:        "notraffic (mbps)",
+			device:      "notraffic",
+			unit:        Mbps,
+			inWant:      0.0,
+			outWant:     0.0,
+			errExpected: false,
+		},
+		{
+			name:        "one second (bps)",
+			device:      "onesec",
+			unit:        Bps,
+			inWant:      1024.0,
+			outWant:     2048.0,
+			errExpected: false,
+		},
+		{
+			name:        "one second (kbps)",
+			device:      "onesec",
+			unit:        Kbps,
+			inWant:      1.0,
+			outWant:     2.0,
+			errExpected: false,
+		},
+		{
+			name:        "five seconds (bps)",
+			device:      "fivesec",
+			unit:        Bps,
+			inWant:      130841.6,
+			outWant:     100916.8,
+			errExpected: false,
+		},
+		{
+			name:        "five seconds (kbps)",
+			device:      "fivesec",
+			unit:        Kbps,
+			inWant:      127.77500,
+			outWant:     98.5515625,
+			errExpected: false,
+		},
+		{
+			name:        "bad device name",
+			device:      "not a device in the map",
+			errExpected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			inGot, outGot, err := testAvgData.Avg(test.device, test.unit)
+
+			if test.errExpected && err == nil {
+				t.Fatalf("Error expected but none was returned")
+			}
+
+			if !test.errExpected && err != nil {
+				t.Fatalf("Error not expected but one was returned: %s", err)
+			}
+
+			if inGot != test.inWant {
+				t.Errorf("In: got %f, want %f", inGot, test.inWant)
+			}
+
+			if outGot != test.outWant {
+				t.Errorf("Out: got %f, want %f", outGot, test.outWant)
+			}
+		})
+	}
+}

--- a/throughput/unit.go
+++ b/throughput/unit.go
@@ -2,6 +2,7 @@ package throughput
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -9,11 +10,11 @@ import (
 type Unit int
 
 const (
-	Bps  Unit = 1
-	Kbps Unit = 10
-	Mbps Unit = 20
-	Gbps Unit = 30
-	Tbps Unit = 40
+	Bps Unit = iota
+	Kbps
+	Mbps
+	Gbps
+	Tbps
 )
 
 var allUnits = []Unit{Bps, Kbps, Mbps, Gbps, Tbps}
@@ -21,6 +22,8 @@ var allUnits = []Unit{Bps, Kbps, Mbps, Gbps, Tbps}
 // String implements Stringer for a Unit.
 func (u Unit) String() string {
 	switch u {
+	case Bps:
+		return "bps"
 	case Kbps:
 		return "kbps"
 	case Mbps:
@@ -30,11 +33,11 @@ func (u Unit) String() string {
 	case Tbps:
 		return "tbps"
 	default:
-		return "bps"
+		return "unk"
 	}
 }
 
-// ParseUnit returns the Unit associated with the input. Use the string form
+// ParseUnit returns the Unit associated with a unit name. Use the string form
 // of the const name for the unit that you want. Parsing is not case sensitive.
 // For example, an input of "Bps" or "bps", will return the unit Bps, "Mbps",
 // "mbps", or "mBps" will return the Mbps unit, etc.
@@ -55,4 +58,14 @@ func ParseUnit(u string) (Unit, error) {
 	}
 
 	return Bps, fmt.Errorf("could not parse %q into a Unit", u)
+}
+
+// Base2 returns two raised to the power of the unit.
+func (u Unit) Base2() float64 {
+	return math.Pow(2, float64(u*10))
+}
+
+// Base10 returns ten raised to the power of the unit.
+func (u Unit) Base10() float64 {
+	return math.Pow(10, float64(u*3))
 }

--- a/throughput/unit_test.go
+++ b/throughput/unit_test.go
@@ -25,3 +25,41 @@ func TestBadUnit(t *testing.T) {
 		t.Errorf("ParseUnit() should return an error when passed a bad unit string")
 	}
 }
+
+func TestBase2and10(t *testing.T) {
+	tests := []struct {
+		unit   Unit
+		want2  float64
+		want10 float64
+	}{
+		{
+			unit:   Bps,
+			want2:  1,
+			want10: 1,
+		},
+		{
+			unit:   Kbps,
+			want2:  1024,
+			want10: 1000,
+		},
+		{
+			unit:   Mbps,
+			want2:  1048576,
+			want10: 1000000,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.unit.String(), func(t *testing.T) {
+			got := test.unit.Base2()
+			if got != test.want2 {
+				t.Errorf("%s.base2(): got %.0f, want %.0f", test.unit, got, test.want2)
+			}
+
+			got = test.unit.Base10()
+			if got != test.want10 {
+				t.Errorf("%s.base10(): got %.0f, want %.0f", test.unit, got, test.want10)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes counter rollover problems for 32-bit devices. Includes more test coverage and cleanup as well.